### PR TITLE
Test with Ubuntu 24.04, remove 20.04

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-22.04, ubuntu-24.04 ]
 
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-22.04, ubuntu-24.04 ]
 
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Sounds like 20.04 is going away soon.

https://github.com/actions/runner-images?tab=readme-ov-file#software-and-image-support

> We support (at maximum) 2 GA images and 1 beta image at a time. We begin the deprecation process of the oldest image label once the newest OS image label has been released to GA.

